### PR TITLE
Deprecate direct system index restoration

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -277,7 +277,7 @@ public class RestoreService implements ClusterStateApplier {
                 ).distinct().collect(Collectors.toList());
 
                 final Set<Index> systemIndicesToDelete = new HashSet<>();
-                Set<String> explicitlyRequestedSystemIndices = new HashSet<>();
+                final Set<String> explicitlyRequestedSystemIndices = new HashSet<>();
                 final List<IndexId> indexIdsInSnapshot = repositoryData.resolveIndices(requestedIndicesIncludingSystem);
                 for (IndexId indexId : indexIdsInSnapshot) {
                     IndexMetadata snapshotIndexMetaData = repository.getSnapshotIndexMetaData(repositoryData, snapshotId, indexId);

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -64,6 +64,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -130,6 +131,7 @@ import static org.elasticsearch.snapshots.SnapshotUtils.filterIndices;
 public class RestoreService implements ClusterStateApplier {
 
     private static final Logger logger = LogManager.getLogger(RestoreService.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestoreService.class);
 
     private static final Set<String> UNMODIFIABLE_SETTINGS = unmodifiableSet(newHashSet(
             SETTING_NUMBER_OF_SHARDS,
@@ -275,13 +277,24 @@ public class RestoreService implements ClusterStateApplier {
                 ).distinct().collect(Collectors.toList());
 
                 final Set<Index> systemIndicesToDelete = new HashSet<>();
+                Set<String> explicitlyRequestedSystemIndices = new HashSet<>();
                 final List<IndexId> indexIdsInSnapshot = repositoryData.resolveIndices(requestedIndicesIncludingSystem);
                 for (IndexId indexId : indexIdsInSnapshot) {
                     IndexMetadata snapshotIndexMetaData = repository.getSnapshotIndexMetaData(repositoryData, snapshotId, indexId);
                     if (snapshotIndexMetaData.isSystem()) {
                         systemIndicesToDelete.add(snapshotIndexMetaData.getIndex());
+                        if (requestedIndicesInSnapshot.contains(indexId.getName())) {
+                            explicitlyRequestedSystemIndices.add(indexId.getName());
+                        }
                     }
                     metadataBuilder.put(snapshotIndexMetaData, false);
+                }
+
+                // log a deprecation warning if the any of the indexes to delete were included in the request
+                if (explicitlyRequestedSystemIndices.isEmpty() == false) {
+                    deprecationLogger.deprecate("restore-system-index-from-snapshot",
+                        "Restoring system indices by name is deprecated. Use feature states instead. System indices: "
+                            + explicitlyRequestedSystemIndices);
                 }
 
                 final Metadata metadata = metadataBuilder.build();


### PR DESCRIPTION
This work is supposed to cover two goals:

* Emit a deprecation log when a request explicitly restores a system index (rather than via feature state) if the snapshot has feature states
* Throw an exception if a feature state is requested but it's not in the snapshot

The `getFeatureStatesToRestore` method already throws an exception if a requested feature state isn't in the snapshot, so I added an integration test to cover this case.

If one of the indices in the restore request is a system index, it might be from a feature that wasn't snapshotted, so we won't know that it's a system index until we've resolved the index against repository data. We can check that each system index has not been directly requested as we build the list of system indices to delete.